### PR TITLE
Autodetect .yml files as 'ruby'

### DIFF
--- a/getlocalization/api/files/FileFormat.py
+++ b/getlocalization/api/files/FileFormat.py
@@ -13,6 +13,7 @@ FORMATS = [['.po', 'gettext'],
            ['.php', 'phparray'],
            ['.docx', 'docx'],
            ['.txt', 'plain'],
+           ['.yml', 'ruby'],
            ['.strings', 'ios']
           ]
 


### PR DESCRIPTION
Fixes getlocalization/python-glcli#4
